### PR TITLE
Add Dockerfiles for server and worker

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,20 @@
+FROM rust:1.88.0
+
+WORKDIR /app
+
+ARG APP_PROFILE
+
+ENV APP_PROFILE=${APP_PROFILE}
+
+# copy binary from build stage
+COPY target/release/server .
+
+# copy base configuration files
+COPY base.toml .
+
+# copy profile-specific configuration file
+COPY base.${APP_PROFILE}.toml .
+
+RUN chmod +x server
+
+CMD ["./server"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,20 @@
+FROM rust:1.88.0
+
+WORKDIR /app
+
+ARG APP_PROFILE
+
+ENV APP_PROFILE=${APP_PROFILE}
+
+# copy binary from build stage
+COPY target/release/worker .
+
+# copy base configuration files
+COPY base.toml .
+
+# copy profile-specific configuration file
+COPY base.${APP_PROFILE}.toml .
+
+RUN chmod +x worker
+
+CMD ["./worker"]


### PR DESCRIPTION
Introduces Dockerfile.server and Dockerfile.worker to containerize the Rust server and worker binaries. Each Dockerfile supports profile-specific configuration via the APP_PROFILE argument and copies the necessary configuration files for deployment.