### PR TITLE
Switch server dependencies to local paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
  "uuid",
 ]
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -40,35 +40,35 @@ redis = { workspace = true }
 apalis = { version = "0.7.1", features = ["retry", "limit", "timeout"] }
 apalis-redis = "0.7.1"
 
-conf = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "conf", features = ["feed", "agent_redis"] }
-common = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "common" }
-search = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "search", default-features = false, features = [
-    "feed",
-] }
-protocol = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "protocol", default-features = false, features = [
-    "feed",
-    "redis"
-] }
-seaorm-db = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "seaorm-db", default-features = false, features = [
-    "feed",
-] }
-feed = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "feed", default-features = false, features = ["redis"]}
+# conf = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "conf", features = ["feed", "agent_redis"] }
+# common = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "common" }
+# search = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "search", default-features = false, features = [
+#     "feed",
+# ] }
+# protocol = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "protocol", default-features = false, features = [
+#     "feed",
+#     "redis"
+# ] }
+# seaorm-db = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "seaorm-db", default-features = false, features = [
+#     "feed",
+# ] }
+# feed = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", version = "*", package = "feed", default-features = false, features = ["redis"]}
 
 
 
-# conf = { path = "../../../WisAgent/crates/conf", version = "*", package = "conf", features = [
-#     "feed",
-#     "agent_redis"
-# ] }
-# common = { path = "../../../WisAgent/crates/common", version = "*", package = "common" }
-# search = { path = "../../../WisAgent/crates/search", version = "*", package = "search", default-features = false, features = [
-#     "feed",
-# ] }
-# protocol = { path = "../../../WisAgent/crates/protocol", version = "*", package = "protocol", default-features = false, features = [
-#     "feed",
-#     "redis",
-# ] }
-# seaorm-db = { path = "../../../WisAgent/crates/seaorm-db", version = "*", package = "seaorm-db", default-features = false, features = [
-#     "feed",
-# ] }
-# feed = { path = "../../../WisAgent/crates/feed", version = "*", package = "feed", default-features = false, features = ["redis"]}
+conf = { path = "../../../WisAgent/crates/conf", version = "*", package = "conf", features = [
+    "feed",
+    "agent_redis"
+] }
+common = { path = "../../../WisAgent/crates/common", version = "*", package = "common" }
+search = { path = "../../../WisAgent/crates/search", version = "*", package = "search", default-features = false, features = [
+    "feed",
+] }
+protocol = { path = "../../../WisAgent/crates/protocol", version = "*", package = "protocol", default-features = false, features = [
+    "feed",
+    "redis",
+] }
+seaorm-db = { path = "../../../WisAgent/crates/seaorm-db", version = "*", package = "seaorm-db", default-features = false, features = [
+    "feed",
+] }
+feed = { path = "../../../WisAgent/crates/feed", version = "*", package = "feed", default-features = false, features = ["redis"]}

--- a/crates/server/src/routers/feed/feeds.rs
+++ b/crates/server/src/routers/feed/feeds.rs
@@ -158,7 +158,7 @@ pub async fn verify(
         ("channel" = String, Path, description = "频道"),
     ),
     responses(
-        (status = 200, body = bool),
+        (status = 200, body = JobDetail),
     ),
     tag = FEED_TAG,
 )]
@@ -166,7 +166,7 @@ pub async fn verify_detail(
     Query(payload): Query<FeedRequest>,
     State(state): State<AppState>,
     User(user): User,
-) -> Result<ApiResponse<JobDetail>, ApiError> {
+) -> Result<ApiResponse<Option<JobDetail>>, ApiError> {
     tracing::info!("verify papers status");
     let job = VerifyJob::new(
         state.redis.pool,

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -19,7 +19,7 @@ conf = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", 
     "agent_redis",
 ] }
 feed = { git = "ssh://git@github.com/AtomInnoLab/WisAgent.git", branch = "dev", package = "feed", default-features = false, features = [
-    "feed",
+    "redis",
 ] }
 
 


### PR DESCRIPTION
Updated crates/server/Cargo.toml to use local path dependencies for WisAgent crates instead of git sources. Fixed response types in feed router endpoints and added dispatch for updating user interest metadata after setting interests. Also changed worker crate feed feature from 'feed' to 'redis'.